### PR TITLE
[feat]: Add date range support and fix message duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Run the application through the following command:
 uv run summarizer --help
 ```
 
+### Single Date
+
 You can provide your email address and Webex token via CLI options, environment variables, or interactive prompt (prompting for email first, then token):
 
 ```bash
@@ -50,8 +52,23 @@ uv run summarizer --target-date=2024-06-01
 
 If not provided, you will be prompted for your email and token interactively.
 
+### Date Range
+
+You can also specify a date range to summarize activity over multiple days. The `--start-date` and `--end-date` options are mutually exclusive with `--target-date`.
+
+```bash
+uv run summarizer --user-email=you@example.com --webex-token=YOUR_TOKEN --start-date=2024-06-01 --end-date=2024-06-03
+```
+
+### Other Options
+
 Other options (with defaults):
+
+- `--target-date`: The specific date to summarize (e.g., `2024-06-01`).
+- `--start-date`: The start date for a range summary.
+- `--end-date`: The end date for a range summary.
 - `--context-window-minutes`: Context window in minutes (default: 15)
 - `--passive-participation`: Include conversations where you only received messages (default: False)
 - `--time-display-format`: Time display format ('12h' or '24h', default: '12h')
 - `--room-chunk-size`: Room fetch chunk size (default: 50)
+- `--debug`: Enable debug logging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev = [
 [project.scripts]
 summarizer = "summarizer.cli:app"
 
+[tool.setuptools.packages.find]
+include = ["summarizer*"]
+
 [tool.uv]
 package = true
 

--- a/summarizer/cli.py
+++ b/summarizer/cli.py
@@ -29,17 +29,109 @@ class TimeDisplayFormat(str, Enum):
     h24 = "24h"
 
 
+#
+# Date argument parsing and validation helpers
+#
+
+
+def _handle_date_range(start_date: str, end_date: str) -> tuple[datetime, datetime]:
+    """Parse and validate the date range."""
+    try:
+        start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+    except ValueError as exc:
+        typer.echo("[red]Invalid date format for range. Please use YYYY-MM-DD.[/red]")
+        raise typer.Exit(1) from exc
+    if end_dt < start_dt:
+        typer.echo("[red]End date must not be before start date.[/red]")
+        raise typer.Exit(1)
+    return start_dt, end_dt
+
+
+def _handle_single_date(target_date: str | None) -> datetime:
+    """Prompt for and parse a single date if needed."""
+    if target_date is None:
+        current_date = datetime.now().strftime("%Y-%m-%d")
+        target_date = typer.prompt(
+            "Enter the date to summarize (YYYY-MM-DD)",
+            default=current_date,
+        )
+    # This check is for safety, as prompt should handle it.
+    if target_date is None:
+        typer.echo("[red]No date provided.[/red]")
+        raise typer.Exit(1)
+    try:
+        return datetime.strptime(target_date, "%Y-%m-%d")
+    except ValueError as exc:
+        typer.echo("[red]Invalid date format. Please use YYYY-MM-DD.[/red]")
+        raise typer.Exit(1) from exc
+
+
+def _validate_and_parse_dates(
+    target_date: str | None,
+    start_date: str | None,
+    end_date: str | None,
+) -> tuple[datetime | None, datetime | None, datetime | None, str]:
+    """Validate mutually exclusive date/range args and parse to datetime objects.
+
+    Returns:
+        (parsed_target_date, parsed_start_date, parsed_end_date, mode)
+        mode is 'single' or 'range'.
+
+    Raises:
+        typer.Exit on error.
+    """
+    # Mutually exclusive validation: either a single date OR a date range
+    if target_date and (start_date or end_date):
+        typer.echo(
+            "[red]Cannot use --target-date with --start-date or --end-date. "
+            "Please choose one mode.[/red]"
+        )
+        raise typer.Exit(1)
+    if (start_date and not end_date) or (end_date and not start_date):
+        typer.echo(
+            "[red]Both --start-date and --end-date must be provided for a range.[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Date range mode
+    if start_date and end_date:
+        start_dt, end_dt = _handle_date_range(start_date, end_date)
+        return None, start_dt, end_dt, "range"
+
+    # Single date mode
+    parsed_date = _handle_single_date(target_date)
+    return parsed_date, None, None, "single"
+
+
+def _run_for_date(
+    config: AppConfig,
+    date_header: bool,
+) -> None:
+    logger.info("Attempting to log into Webex API as user %s", config.user_email)
+    logger.info("Targeted date for summarization: %s", config.target_date)
+    logger.info("Context window size: %d minutes", config.context_window_minutes)
+    logger.info("Passive participation: %s", config.passive_participation)
+    logger.info("Time display format: %s", config.time_display_format)
+    logger.info("Room fetch chunk size: %d", config.room_chunk_size)
+    run_app(config, date_header=date_header)
+
+
 @app.command()
 def main(
     user_email: Annotated[
-        str, typer.Option(..., envvar="USER_EMAIL", prompt="Enter your Cisco email")
+        str,
+        typer.Option(..., envvar="USER_EMAIL", prompt="Enter your Cisco email"),
     ],
     webex_token: Annotated[
         str,
         typer.Option(
             ...,
             envvar="WEBEX_TOKEN",
-            prompt="Enter your Webex access token (https://developer.webex.com/docs/getting-started)",
+            prompt=(
+                "Enter your Webex access token "
+                "(https://developer.webex.com/docs/getting-started)"
+            ),
             hide_input=True,
         ),
     ],
@@ -47,21 +139,30 @@ def main(
     target_date: Annotated[
         str | None,
         typer.Option(
-            help="Date in YYYY-MM-DD format (mutually exclusive with --start-date/--end-date)",
+            help=(
+                "Date in YYYY-MM-DD format "
+                "(mutually exclusive with --start-date/--end-date)"
+            ),
             metavar="YYYY-MM-DD",
         ),
     ] = None,
     start_date: Annotated[
         str | None,
         typer.Option(
-            help="Start date for range in YYYY-MM-DD format (mutually exclusive with --target-date)",
+            help=(
+                "Start date for range in YYYY-MM-DD format "
+                "(mutually exclusive with --target-date)"
+            ),
             metavar="YYYY-MM-DD",
         ),
     ] = None,
     end_date: Annotated[
         str | None,
         typer.Option(
-            help="End date for range in YYYY-MM-DD format (mutually exclusive with --target-date)",
+            help=(
+                "End date for range in YYYY-MM-DD format "
+                "(mutually exclusive with --target-date)"
+            ),
             metavar="YYYY-MM-DD",
         ),
     ] = None,
@@ -82,35 +183,15 @@ def main(
         logger.setLevel(logging.DEBUG)
         logger.debug("Debug logging enabled")
 
-    # Mutually exclusive validation
-    # Either pick a single date OR pick a date range
-    if target_date and (start_date or end_date):
-        typer.echo(
-            "[red]Cannot use --target-date with --start-date or --end-date. Please choose one mode.[/red]"
-        )
-        raise typer.Exit(1)
-    if (start_date and not end_date) or (end_date and not start_date):
-        typer.echo(
-            "[red]Both --start-date and --end-date must be provided for a range.[/red]"
-        )
-        raise typer.Exit(1)
+    parsed_target_date, parsed_start_date, parsed_end_date, mode = (
+        _validate_and_parse_dates(target_date, start_date, end_date)
+    )
 
-    if start_date and end_date:
-        # Parse date range
-        try:
-            start_dt = datetime.strptime(start_date, "%Y-%m-%d")
-            end_dt = datetime.strptime(end_date, "%Y-%m-%d")
-        except ValueError as exc:
-            typer.echo(
-                "[red]Invalid date format for range. Please use YYYY-MM-DD.[/red]"
-            )
-            raise typer.Exit(1) from exc
-        if end_dt < start_dt:
-            typer.echo("[red]End date must not be before start date.[/red]")
-            raise typer.Exit(1)
-        # Iterate over range (inclusive)
-        current = start_dt
-        while current <= end_dt:
+    if mode == "range":
+        # Iterate over date range (inclusive)
+        current = parsed_start_date
+        assert current is not None and parsed_end_date is not None
+        while current <= parsed_end_date:
             config = AppConfig(
                 webex_token=webex_token,
                 user_email=user_email,
@@ -120,48 +201,23 @@ def main(
                 time_display_format=time_display_format.value,
                 room_chunk_size=room_chunk_size,
             )
-            run_app(config, date_header=True)
+            _run_for_date(config, date_header=True)
             current += timedelta(days=1)
         return
 
-    # Single date mode (default)
-    if target_date is None:
-        current_date = datetime.now().strftime("%Y-%m-%d")
-        target_date = typer.prompt(
-            "Enter the date to summarize (YYYY-MM-DD)",
-            default=current_date,
-        )
-
-    # At this point, target_date must be a string.
-    if target_date is None:
-        typer.echo("[red]No date provided.[/red]")
-        raise typer.Exit(1)
-
-    # Parse target_date
-    try:
-        parsed_date = datetime.strptime(target_date, "%Y-%m-%d")
-    except ValueError as exc:
-        typer.echo("[red]Invalid date format. Please use YYYY-MM-DD.[/red]")
-        raise typer.Exit(1) from exc
-
-    # Construct AppConfig
+    # Single date mode
+    assert parsed_target_date is not None
+    # Construct AppConfig for a single date
     config = AppConfig(
         webex_token=webex_token,
         user_email=user_email,
-        target_date=parsed_date,
+        target_date=parsed_target_date,
         context_window_minutes=context_window_minutes,
         passive_participation=passive_participation,
         time_display_format=time_display_format.value,
         room_chunk_size=room_chunk_size,
     )
-    logger.info("Attempting to log into Webex API as user %s", user_email)
-    logger.info("Targeted date for summarization: %s", target_date)
-    logger.info("Context window size: %d minutes", context_window_minutes)
-    logger.info("Passive participation: %s", passive_participation)
-    logger.info("Time display format: %s", time_display_format.value)
-    logger.info("Room fetch chunk size: %d", room_chunk_size)
-
-    run_app(config, date_header=False)
+    _run_for_date(config, date_header=False)
 
 
 if __name__ == "__main__":

--- a/summarizer/console_ui.py
+++ b/summarizer/console_ui.py
@@ -182,3 +182,18 @@ def _format_time(dt: datetime | None, fmt: str) -> str:
         return dt.strftime("%H:%M:%S")
     else:
         return dt.strftime("%I:%M:%S %p")
+
+
+# For the range of dates, print a header with each date
+# in the range for ease of use/viewing.
+def print_date_header(date: datetime) -> None:
+    """Print a visually distinct header for a date using box-drawing characters."""
+    date_str = date.strftime("%Y-%m-%d")
+    header_text = f" {date_str} — Messages "
+    width = max(60, len(header_text) + 8)
+    top = f"╔{'═' * (width - 2)}╗"
+    mid = f"║{header_text.center(width - 2)}║"
+    bot = f"╚{'═' * (width - 2)}╝"
+    console.print("\n" + top, style="bold blue")
+    console.print(mid, style="bold white")
+    console.print(bot, style="bold blue")

--- a/summarizer/runner.py
+++ b/summarizer/runner.py
@@ -18,7 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 def run_app(config: AppConfig, date_header: bool = False) -> None:
-    """Run the application with the given configuration. Optionally print a date header."""
+    """Run the application with the given configuration.
+
+    Optionally print a date header.
+    """
     local_tz = datetime.now().astimezone().tzinfo
     if local_tz is None:
         console.print(

--- a/summarizer/runner.py
+++ b/summarizer/runner.py
@@ -17,8 +17,8 @@ from summarizer.webex import WebexClient
 logger = logging.getLogger(__name__)
 
 
-def run_app(config: AppConfig) -> None:
-    """Run the application with the given configuration."""
+def run_app(config: AppConfig, date_header: bool = False) -> None:
+    """Run the application with the given configuration. Optionally print a date header."""
     local_tz = datetime.now().astimezone().tzinfo
     if local_tz is None:
         console.print(
@@ -27,6 +27,11 @@ def run_app(config: AppConfig) -> None:
         local_tz = UTC
 
     logger.info("Local timezone is %s", local_tz)
+
+    if date_header:
+        from summarizer.console_ui import print_date_header
+
+        print_date_header(config.target_date)
 
     with console.status("[bold green]Connecting to APIs...[/]"):
         webex_client = WebexClient(config)

--- a/summarizer/webex.py
+++ b/summarizer/webex.py
@@ -60,6 +60,7 @@ class WebexClient:
     def get_rooms_active_since_date(self, date: datetime) -> list[Room]:
         """Get all rooms that have had activity since the given date."""
         active_rooms: list[Room] = []
+        seen_room_ids: set[str] = set()  # Track seen room IDs
         rooms = self._client.rooms.list(
             max=self.config.room_chunk_size, sortBy="lastactivity"
         )
@@ -73,6 +74,15 @@ class WebexClient:
             task = progress.add_task("Scanning rooms for activity...", total=None)
             for room in rooms:
                 logger.debug("Processing room: id=%s, title=%s", room.id, room.title)
+                if room.id in seen_room_ids:
+                    logger.debug(
+                        "Room %s (ID %s) already processed, skipping...",
+                        room.title,
+                        room.id,
+                    )
+                    progress.update(task, advance=1)
+                    continue
+                seen_room_ids.add(room.id)
                 if room.lastActivity is None:
                     progress.update(task, advance=1)
                     logger.debug(
@@ -112,6 +122,7 @@ class WebexClient:
     ) -> list[Message]:
         """Get all messages for the given rooms and date."""
         messages: list[Message] = []
+        seen_message_ids: set[str] = set()  # Track seen message IDs
         with Progress(
             SpinnerColumn(),
             TextColumn("[bold blue]Fetching messages from active rooms..."),
@@ -139,15 +150,23 @@ class WebexClient:
                     result: MessageAnalysisResult = future.result()
                     if result.messages:
                         for msg in result.messages:
-                            logger.debug(
-                                "Message ID %s in room %s (ID %s) from sender %s at %s",
-                                msg.id,
-                                result.room.title,
-                                result.room.id,
-                                msg.sender.display_name,
-                                msg.timestamp,
-                            )
-                        messages.extend(result.messages)
+                            # Only add if we haven't seen this message ID before
+                            if msg.id not in seen_message_ids:
+                                seen_message_ids.add(msg.id)
+                                logger.debug(
+                                    "Message ID %s in room %s (ID %s) from sender %s at %s",
+                                    msg.id,
+                                    result.room.title,
+                                    result.room.id,
+                                    msg.sender.display_name,
+                                    msg.timestamp,
+                                )
+                                messages.append(msg)
+                            else:
+                                logger.debug(
+                                    "Skipping duplicate message ID %s",
+                                    msg.id,
+                                )
                     progress.update(task, advance=1)
 
         logger.info(f"Total messages aggregated: {len(messages)}")

--- a/summarizer/webex.py
+++ b/summarizer/webex.py
@@ -154,7 +154,10 @@ class WebexClient:
                             if msg.id not in seen_message_ids:
                                 seen_message_ids.add(msg.id)
                                 logger.debug(
-                                    "Message ID %s in room %s (ID %s) from sender %s at %s",
+                                    (
+                                        "Message ID %s in room %s (ID %s) from sender "
+                                        "%s at %s"
+                                    ),
                                     msg.id,
                                     result.room.title,
                                     result.room.id,
@@ -286,7 +289,8 @@ def get_messages(
             had_activity_on_or_after_date = True
         elif message_time.date() < date.date():
             logger.debug(
-                "Message %s from email %s is before the target date %s, stopping processing...",
+                "Message %s from email %s is before the target date %s, "
+                "stopping processing...",
                 sdk_message.id,
                 sdk_message.personEmail,
                 date,


### PR DESCRIPTION
# 📝 Description

This pull request introduces a significant enhancement to the CLI, allowing users to summarize their Webex activity over a range of dates instead of just a single day. It also resolves a critical bug where messages were being duplicated in the output when using this new feature.

- **New Feature**: Adds `--start-date` and `--end-date` CLI options to run the summarizer for an inclusive date range.
- **Bug Fix**: Corrects an issue where messages were being fetched and displayed multiple times for each day in the range.
- **Refactoring & Linting**: Refactors the CLI entrypoint to resolve complexity issues flagged by linters and fixes all `ruff` and `xenon` pre-commit errors.
- **Build Fix**: Resolves a `setuptools` build error by explicitly defining the package directory in `pyproject.toml`.
- **Documentation**: Updates the `README.md` to reflect the new date range functionality.

## 🔗 Related Issue(s)

- *No related issues.*

## ✔️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🛠️ Refactoring/Technical debt (internal code improvements with no direct user-facing changes)
- [x] 📄 Documentation update (README, docstrings, etc.)
- [x] ⚙️ Chore (build process, CI, tooling, dependency updates, etc.)

## 🎯 Key Changes & Implementation Details

- **`summarizer/cli.py`**:
  - Added `--start-date` and `--end-date` options using `typer`.
  - Refactored the `main` function into smaller helper functions (`_validate_and_parse_dates`, `_handle_date_range`, `_handle_single_date`) to reduce complexity and improve readability.
- **`summarizer/runner.py`**:
  - Modified `run_app` to accept a `date_header` flag to conditionally print a visual separator for each day when running in range mode.
- **`summarizer/console_ui.py`**:
  - Added a `print_date_header` function that renders an aesthetic, box-style header for each date's output.
- **`summarizer/webex.py`**:
  - Implemented deduplication logic in `get_rooms_active_since_date` and `get_messages_for_rooms` by tracking seen room and message IDs, preventing the same data from being processed multiple times.
- **`pyproject.toml`**:
  - Added a `[tool.setuptools.packages.find]` section to explicitly include the `summarizer` package, resolving a build error caused by the `logs` directory.
- **`README.md`**:
  - Updated the "Usage" section to document the new date range flags and provide examples.

## 🧪 Testing Done

- [x] Manual E2E testing performed (describe steps/scenarios):
  - Scenario 1: Ran `uv run summarizer --start-date YYYY-MM-DD --end-date YYYY-MM-DD` and verified that a distinct, headed output was generated for each day in the range.
  - Scenario 2: Confirmed that the message triplication bug was resolved and each message appeared only once.
  - Scenario 3: Ran with `--target-date` to ensure single-day functionality was not broken.
- [x] All existing tests pass (e.g., `pre-commit run -a`).

## ✅ Checklist

- [x] My code follows the style guidelines of this project (e.g., ran `invoke lint` or `pre-commit run -a`).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (e.g., README.md, task docstrings) if applicable.
- [x] My changes generate no new linting errors or warnings.
- [ ] I have added/updated relevant diagrams (if applicable).
- [ ] I have updated `CHANGELOG.md` or `release-notes.md` (if one exists) with a summary of my changes under the appropriate version (if applicable, for significant user-facing changes or bug fixes).

## 🖼️ Screenshots (if applicable)

Sample of the "broken" behavior:

![Screenshot 2025-06-24 at 06 09 15](https://github.com/user-attachments/assets/ce74e9ef-132d-497a-b208-ee282f4d583c)


## ➡️ Next Steps (if applicable)

*N/A*

## ❓ Questions & Open Items (if applicable)

*N/A*