### PR TITLE
fix: DM conversation naming issue for one-way single-participant conversations

### DIFF
--- a/summarizer/grouping.py
+++ b/summarizer/grouping.py
@@ -72,7 +72,8 @@ def build_dm_conversation(
         (p for p in participants.values() if p.id != user_id), None
     )
 
-    # If we don't have the other participant from messages, try to get it from room memberships
+    # If we don't have the other participant from messages, try to get it from room
+    # memberships
     if other_participant is None and client is not None:
         try:
             memberships = client.memberships.list(roomId=convo_msgs[0].space_id)
@@ -84,7 +85,8 @@ def build_dm_conversation(
                     break
         except Exception as e:
             logger.warning(
-                f"Could not fetch room memberships for space {convo_msgs[0].space_id}: {e}"
+                "Could not fetch room memberships for space "
+                f"{convo_msgs[0].space_id}: {e}"
             )
 
     slug = slugify(other_participant.display_name if other_participant else "unknown")

--- a/summarizer/runner.py
+++ b/summarizer/runner.py
@@ -79,6 +79,7 @@ def run_app(config: AppConfig, date_header: bool = False) -> None:
         context_window,
         user_id,
         include_passive=config.passive_participation,
+        client=webex_client.client,
     )
 
     # Improved conversation reporting

--- a/summarizer/webex.py
+++ b/summarizer/webex.py
@@ -98,6 +98,11 @@ class WebexClient:
         self._client = client or WebexAPI(access_token=config.webex_token)
         self._me: Person | None = None
 
+    @property
+    def client(self) -> WebexAPI:
+        """Get the underlying WebexAPI client."""
+        return self._client
+
     def get_me(self) -> User:
         """Get user information as a User dataclass."""
         if not self._me:

--- a/webexpythonsdk-stubs/webexpythonsdk/__init__.pyi
+++ b/webexpythonsdk-stubs/webexpythonsdk/__init__.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 
-from .models.immutable import Message, Person, Room
+from .models.immutable import Membership, Message, Person, Room
 
 class WebexAPI:
     def __init__(self, access_token: str) -> None: ...
@@ -10,6 +10,8 @@ class WebexAPI:
     def rooms(self) -> RoomsAPI: ...
     @property
     def messages(self) -> MessagesAPI: ...
+    @property
+    def memberships(self) -> MembershipsAPI: ...
 
 class PeopleAPI:
     def me(self) -> Person: ...
@@ -29,3 +31,10 @@ class MessagesAPI:
         roomId: str,  # noqa: N803
         max: int = ...,
     ) -> Generator[Message, None, None]: ...
+
+class MembershipsAPI:
+    def list(
+        self,
+        roomId: str,  # noqa: N803
+        max: int = ...,
+    ) -> Generator[Membership, None, None]: ...

--- a/webexpythonsdk-stubs/webexpythonsdk/models/immutable.pyi
+++ b/webexpythonsdk-stubs/webexpythonsdk/models/immutable.pyi
@@ -21,3 +21,10 @@ class Room:
     title: str
     type: RoomType
     lastActivity: datetime | None  # noqa: N803, N815
+
+class Membership:
+    id: str
+    roomId: str  # noqa: N803, N815
+    personId: str  # noqa: N803, N815
+    personEmail: str  # noqa: N803, N815
+    isModerator: bool  # noqa: N803, N815


### PR DESCRIPTION
### Problem
Previously, when a DM conversation contained only messages from the authenticated user (i.e., the user sent a message but received no reply within the conversation window), the conversation would be named with a generic identifier like `dm-unknown-1` instead of showing the actual target recipient's name. This made it difficult to identify which person the conversation was with.

### Root Cause
The issue occurred in the `build_dm_conversation` function, which determined conversation participants solely from message senders. When only the authenticated user had sent messages, the function couldn't identify the "other participant" and defaulted to using "unknown" in the conversation ID.

### Solution
This PR enhances the DM conversation building logic to fetch room membership information from the Webex API when message senders alone don't provide sufficient participant information.

### Changes Made

#### Core Logic Enhancement (`summarizer/grouping.py`)
- **Enhanced `build_dm_conversation` function**: Added optional `WebexAPI` client parameter and fallback logic to fetch room memberships when the other participant cannot be identified from messages
- **Updated function signatures**: Modified `group_dm_conversations` and `group_all_conversations` to accept and pass through the WebexAPI client
- **Added error handling**: Gracefully handles API failures when fetching room memberships with appropriate logging

#### WebexAPI Client Access (`summarizer/webex.py`)
- **Added `client` property**: Exposed the underlying `WebexAPI` instance through a public property on `WebexClient` for use in conversation grouping logic

#### Integration (`summarizer/runner.py`)
- **Updated function call**: Modified the call to `group_all_conversations` to pass the WebexAPI client instance

#### Type Safety (`webexpythonsdk-stubs/`)
- **Added Memberships API**: Extended WebexAPI stub with `memberships` property and `MembershipsAPI` class
- **Added Membership model**: Created `Membership` class stub with required properties (`id`, `roomId`, `personId`, `personEmail`, `isModerator`)

### How It Works
1. **Primary approach**: Attempts to identify the other participant from message senders (existing behavior)
2. **Fallback approach**: When that fails, queries the Webex API's memberships endpoint for the room
3. **Participant resolution**: Finds the membership record for a person who isn't the authenticated user
4. **Name resolution**: Uses the existing `safe_get_person` function to get the person's display name
5. **Graceful degradation**: Falls back to "unknown" if API calls fail, maintaining backward compatibility

### Results
After this fix, DM conversations now display meaningful names even when only the authenticated user has sent messages:

**Before:**
~~~
dm-unknown-1 | 1 messages | Participants: Christopher Hart | ...
~~~

**After:**
~~~
dm-andrea-testino-15 | 1 messages | Participants: Christopher Hart | ...
~~~

### Testing
- ✅ Verified fix works with the original reproduction case
- ✅ Confirmed backward compatibility when both participants have sent messages  
- ✅ Tested graceful degradation when API calls fail
- ✅ No linting errors introduced

### Impact
- **User Experience**: Significantly improves conversation identification in the daily summary
- **Debugging**: Makes it easier to understand communication patterns and follow up on unanswered messages
- **Backward Compatibility**: Maintains all existing functionality while adding the enhancement
- **Performance**: Minimal impact - API calls only made when necessary (fallback scenario)